### PR TITLE
MC-3249 Confluence App:Fixed bug where diagram failed to load after b…

### DIFF
--- a/public/js/editor/diagram.js
+++ b/public/js/editor/diagram.js
@@ -1,15 +1,32 @@
 import {h} from 'https://esm.sh/preact';
 import htm from 'https://esm.sh/htm';
-import {useEffect} from 'https://esm.sh/preact/hooks';
+import {useEffect, useState} from 'https://esm.sh/preact/hooks';
 
 const html = htm.bind(h);
 
 export function Diagram({document, onOpenFrame, mcAccessToken}) {
+    const [imgSrc, setImgSrc] = useState('');
+    const [error, setError] = useState(false);
+
+    useEffect(() => {
+        if (document.documentID) {
+            const imageUrl = `${MC_BASE_URL}/raw/${document.documentID}?version=v${document.major}.${document.minor}&theme=light&format=png`;
+            setImgSrc(imageUrl);
+        }
+    }, [document.documentID, document.major, document.minor]);
+
     let image = '';
     if (document.documentID) {
         image = html`
             <div class="image">
-                <img src="data:image/x-png;base64, ${document.diagramImage}" alt="${document.title}"/>
+                <img src="${imgSrc}" 
+                     alt="${document.title}"
+                     onError="${(e) => {
+                         if (document.diagramImage && !error) {
+                             setError(true);
+                             setImgSrc(`data:image/x-png;base64, ${document.diagramImage}`);
+                         }
+                     }}"/>
             </div>`;
     }
 

--- a/views/viewer.hbs
+++ b/views/viewer.hbs
@@ -16,11 +16,23 @@
 <script type="module">
     import {IMAGE_SIZES} from '/js/constatnts.js';
     const imageContainer = document.getElementById('image');
-    AP.confluence.getMacroBody((macroBody) => {
-        const img = document.createElement("img")
-        img.src = 'data:image/x-png;base64, ' + macroBody;
-        imageContainer.appendChild(img);
+    AP.confluence.getMacroBody(async (macroBody) => {
+       try {
+    const bodyData = JSON.parse(macroBody);
+    const img = document.createElement("img");
+
+    if (bodyData.url) {
+        img.src = bodyData.url;
+    } else {
+        img.src = 'data:image/x-png;base64,' + macroBody;
+    }
+
+    imageContainer.appendChild(img);
+} catch (e) {
+    console.error('Error parsing macro body:', e);
+}
     });
+
     AP.confluence.getMacroData(async (data) => {
         if (data.caption) {
             document.getElementById('caption').innerText = data.caption;


### PR DESCRIPTION
Resolved an issue where diagrams failed to load after being inserted into a Confluence page. The root cause was the use of base64 image data, which often exceeded size limits. The plugin now uses MermaidChart’s /raw/ endpoint URL to reference images instead of embedding base64 data