### PR TITLE
Mc 3249 confluence app develop some mermaid diagrams fail to load on confluence page

### DIFF
--- a/public/js/editor/form.js
+++ b/public/js/editor/form.js
@@ -97,7 +97,7 @@ export function Form({ mcAccessToken, user, onLogout }) {
   useEffect(() => {
     async function fetchData() {
       try {
-        const locationData = await getLocationWithTimeout(2000);
+        const locationData = await getLocationWithTimeout(4000);
         setLocation(locationData);
       } catch (error) {
         console.error("Error getting location:", error);

--- a/public/js/editor/form.js
+++ b/public/js/editor/form.js
@@ -24,7 +24,7 @@ function getLocationWithTimeout(timeout) {
 export function Form({ mcAccessToken, user, onLogout }) {
   const [iframeURL, setIframeURL] = useState("");
   const [initialized, setinitialized] = useState(false);
-  const [location, setLocation] = useState(null);
+  const [location, setLocation] = useState("");
 
   const onOpenFrame = (url) => {
     setIframeURL(url);

--- a/public/js/editor/form.js
+++ b/public/js/editor/form.js
@@ -4,6 +4,7 @@ import htm from "https://esm.sh/htm";
 import { IMAGE_SIZES } from "/js/constatnts.js";
 import { Diagram } from "./diagram.js";
 import { Header } from "./header.js";
+import { compressBase64Image,sizeConfig, calculateDataSize } from "/js/imageUtils.js";
 
 const html = htm.bind(h);
 
@@ -62,15 +63,47 @@ export function Form({ mcAccessToken, user, onLogout }) {
       setinitialized(true);
     });
 
-    window.AP.events.on("dialog.submit", async () => {
-      const { diagramImage: _, ...saveData } = dataRef.current;
-      await window.AP.confluence.saveMacro(
-        saveData,
-        dataRef.current.diagramImage
-      );
+  window.AP.events.on("dialog.submit", async () => {
+    const { diagramImage, ...saveData } = dataRef.current;
+    const macroParams = {
+      documentID: saveData.documentID,
+      projectID: saveData.projectID,
+      major: saveData.major,
+      minor: saveData.minor,
+      caption: saveData.caption,
+      diagramCode: saveData.diagramCode,
+      size: saveData.size
+    };
+    
+    try {
+      let bodyDataToSave = diagramImage;
+      if (diagramImage && diagramImage.length > 0) {
+        const macroParamsSize = calculateDataSize(macroParams);
+        const bodyDataSize = calculateDataSize(diagramImage);
+        const totalSize = macroParamsSize + bodyDataSize;
 
+        if (totalSize > sizeConfig.maxUncompressedSize) {
+          bodyDataToSave = await compressBase64Image(
+            diagramImage, 
+            sizeConfig.compressionQuality, 
+            sizeConfig.compressionMaxWidth
+          ).catch(() => diagramImage);
+          
+          macroParams.diagramCode = await compressBase64Image(
+            saveData.diagramCode, 
+            sizeConfig.compressionQuality, 
+            sizeConfig.compressionMaxWidth
+          ).catch(() => saveData.diagramCode);
+        } 
+      }
+      
+      await window.AP.confluence.saveMacro(macroParams, bodyDataToSave);
       window.AP.confluence.closeMacroEditor();
-    });
+
+    } catch (error) {
+      console.error("The diagram is too large to save, Try simplifying your diagram or reducing its complexity");
+    }
+  });
 
     window.AP.dialog.disableCloseOnSubmit();
 

--- a/public/js/imageUtils.js
+++ b/public/js/imageUtils.js
@@ -1,0 +1,71 @@
+// Configuration for size limits and compression settings
+export const sizeConfig = {
+  maxUncompressedSize: 1572864, 
+  compressionQuality: 0.8,
+  compressionMaxWidth: 1000
+};
+
+/**
+ * Compresses a base64 image 
+ * @param {string} base64String - The base64 image string
+ * @param {number} quality - Quality factor (0.1 to 1.0)
+ * @param {number} maxWidth - Maximum width for resizing
+ * @returns {Promise<string>} - Compressed base64 string
+ */
+export function compressBase64Image(base64String, quality = sizeConfig.compressionQuality, maxWidth = sizeConfig.compressionMaxWidth) {
+  return new Promise((resolve, reject) => {
+    try {
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+      const img = new Image();
+      
+      const timeout = setTimeout(() => {
+        reject(new Error('Image compression timeout'));
+      }, 10000); 
+      
+      img.onload = function() {
+        clearTimeout(timeout);
+        try {
+          let { width, height } = img;
+          if (width > maxWidth) {
+            height = (height * maxWidth) / width;
+            width = maxWidth;
+          }
+          
+          canvas.width = width;
+          canvas.height = height;
+          
+          ctx.drawImage(img, 0, 0, width, height);
+          const compressedBase64 = canvas.toDataURL('image/jpeg', quality);
+          
+          const base64Data = compressedBase64.split(',')[1];
+          resolve(base64Data);
+        } catch (error) {
+          reject(new Error(`Canvas compression failed: ${error.message}`));
+        }
+      };
+      
+      img.onerror = function() {
+        clearTimeout(timeout);
+        reject(new Error('Failed to load image for compression'));
+      };
+      
+      img.src = 'data:image/png;base64,' + base64String;
+    } catch (error) {
+      reject(new Error(`Image compression setup failed: ${error.message}`));
+    }
+  });
+}
+
+/**
+ * Calculate the size of data in bytes
+ * @param {string|object} data - The data to calculate size for
+ * @returns {number} Size in bytes
+ */
+export const calculateDataSize = (data) => {
+  return new TextEncoder().encode(
+    typeof data === 'string' ? data : JSON.stringify(data)
+  ).length;
+};
+
+


### PR DESCRIPTION
Resolved an issue where Mermaid diagrams were not rendering properly on Confluence pages due to oversized base64-encoded image data,which caused API failures. The plugin now compresses the base64 image before saving it via the Confluence API, significantly reducing payload size and improving rendering reliability