### PR TITLE
updated the baseUrl to use new mermaid ai domain

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,8 @@
 import {fetchToken, saveToken} from '../utils/index.js';
 import {MermaidChart} from '../utils/MermaidChart.js';
 
-const MC_BASE_URL = process.env.MC_BASE_URL || "https://test.mermaidchart.com";
+// const MC_BASE_URL = process.env.MC_BASE_URL || "https://test.mermaidchart.com";
+const MC_BASE_URL = "https://mermaid.ai";
 
 export default function routes(app, addon) {
 

--- a/utils/MermaidChart.js
+++ b/utils/MermaidChart.js
@@ -2,7 +2,7 @@ import {v4 as uuid} from 'uuid';
 import fetch from 'node-fetch';
 import {getEncodedSHA256Hash} from './index.js';
 
-const defaultBaseURL = 'https://test.mermaidchart.com';
+const defaultBaseURL = 'https://mermaid.ai';
 
 const CLIENT_KEY = 'all';
 


### PR DESCRIPTION
This pull request updates the base URL for Mermaid Chart API calls from the test environment to the mermaid.ai  This ensures that all requests are now directed to the correct live service.

API endpoint update:

* Changed the `MC_BASE_URL` constant in `routes/index.js` to use `https://mermaid.ai` instead of the test URL.
* Updated the `defaultBaseURL` in `utils/MermaidChart.js` to `https://mermaid.ai` to match the new production endpoint.