### PR TITLE
update the domain of the plugin for test env

### DIFF
--- a/atlassian-connect.json
+++ b/atlassian-connect.json
@@ -3,7 +3,7 @@
   "name": "Mermaid chart application",
   "description": "Mermaid chart application",
   "//baseUrl": "{{localBaseUrl}}",
-  "baseUrl": "https://confluencetest.mermaidchart.com",
+  "baseUrl": "https://confluencetest.mermaid.ai",
   "authentication": {
     "type": "jwt"
   },

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   "preview": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://confluencetest.mermaidchart.com",
+    "localBaseUrl": "https://confluencetest.mermaid.ai",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -23,7 +23,7 @@
   "production": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://confluencetest.mermaidchart.com",
+    "localBaseUrl": "https://confluencetest.mermaid.ai",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ app:
     name: nodejs20.x
 remotes:
   - key: connect
-    baseUrl: https://confluencetest.mermaidchart.com
+    baseUrl: https://confluencetest.mermaid.ai
 connectModules:
   confluence:lifecycle:
     - key: lifecycle-events


### PR DESCRIPTION
This pull request updates the application's base URL from `https://confluencetest.mermaidchart.com` to `https://confluencetest.mermaid.ai` across all configuration files to reflect a new deployment domain. This ensures consistency and proper routing for both preview and production environments.

Configuration updates:

* Changed `baseUrl` in `atlassian-connect.json` to use the new domain `https://confluencetest.mermaid.ai`.
* Updated `localBaseUrl` for both `preview` and `production` environments in `config.json` to `https://confluencetest.mermaid.ai`. [[1]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL15-R15) [[2]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL26-R26)
* Modified the `baseUrl` under `remotes` in `manifest.yml` to point to `https://confluencetest.mermaid.ai`.