### PR TITLE
Mc 4109 add utm source and utm medium for confluence plugin and track non logged in users activity for mixpanel

### DIFF
--- a/public/js/lib/httpClient.js
+++ b/public/js/lib/httpClient.js
@@ -1,8 +1,9 @@
 import axios from 'https://esm.sh/axios';
+import { MC_BASE_URL } from '../../../routes';
 
 
 const httpClient = axios.create({
-  baseURL: "https://test.mermaidchart.com",
+  baseURL: MC_BASE_URL  ,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/public/js/lib/httpClient.js
+++ b/public/js/lib/httpClient.js
@@ -1,9 +1,12 @@
 import axios from 'https://esm.sh/axios';
 import { MC_BASE_URL } from '../../../routes';
 
+const getBaseURL = () => {
+  return window.MC_BASE_URL || "https://test.mermaidchart.com";
+};
 
 const httpClient = axios.create({
-  baseURL: MC_BASE_URL  ,
+  baseURL: getBaseURL(),
   headers: {
     'Content-Type': 'application/json',
   },

--- a/public/js/lib/httpClient.js
+++ b/public/js/lib/httpClient.js
@@ -2,7 +2,7 @@ import axios from 'https://esm.sh/axios';
 
 
 const httpClient = axios.create({
-  baseURL: process.env.MC_BASE_URL || "https://test.mermaidchart.com",
+  baseURL: "https://test.mermaidchart.com",
   headers: {
     'Content-Type': 'application/json',
   },

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,7 @@
 import {fetchToken, saveToken} from '../utils/index.js';
 import {MermaidChart} from '../utils/MermaidChart.js';
 
-const MC_BASE_URL = process.env.MC_BASE_URL || "https://test.mermaidchart.com";
+export const MC_BASE_URL = process.env.MC_BASE_URL || "https://test.mermaidchart.com";
 
 export default function routes(app, addon) {
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,7 @@
 import {fetchToken, saveToken} from '../utils/index.js';
 import {MermaidChart} from '../utils/MermaidChart.js';
 
-export const MC_BASE_URL = process.env.MC_BASE_URL || "https://test.mermaidchart.com";
+const MC_BASE_URL = process.env.MC_BASE_URL || "https://test.mermaidchart.com";
 
 export default function routes(app, addon) {
 

--- a/views/editor.hbs
+++ b/views/editor.hbs
@@ -1,5 +1,6 @@
 {{!< layout}}
 <script type="text/javascript">
+    window.MC_BASE_URL = "{{MC_BASE_URL}}";
     const MC_BASE_URL = "{{MC_BASE_URL}}";
     const JWTToken = "{{token}}";
     const loginState = "{{loginState}}";


### PR DESCRIPTION
This pull request updates how the application determines the base URL for HTTP requests, making it more dynamic and configurable. The changes ensure that the base URL can be set from the server and accessed in client-side code, improving flexibility for different environments.

**Dynamic base URL configuration:**

* [`public/js/lib/httpClient.js`](diffhunk://#diff-47254aa09e5c32f91827c214b819285b32de30fdf654f240c1970345263e019fR2-R9): Changed the way the base URL is set for the Axios HTTP client, now using a global variable (`window.MC_BASE_URL`) if available, falling back to a default value otherwise.
* [`views/editor.hbs`](diffhunk://#diff-2233a214b83773891bd77d7acf664fc443eb5ab39d862b1f37487759c56e7376R3): Injected the `MC_BASE_URL` value into the global `window` object, allowing client-side scripts to access the server-provided base URL.