### PR TITLE
Removed unused import

### DIFF
--- a/public/js/lib/httpClient.js
+++ b/public/js/lib/httpClient.js
@@ -1,5 +1,4 @@
 import axios from 'https://esm.sh/axios';
-import { MC_BASE_URL } from '../../../routes';
 
 const getBaseURL = () => {
   return window.MC_BASE_URL || "https://test.mermaidchart.com";


### PR DESCRIPTION
This pull request makes a minor change to the `public/js/lib/httpClient.js` file, removing an unused import statement for `MC_BASE_URL`. This helps clean up the codebase and avoid unnecessary dependencies.