### PR TITLE
remove hardcode value

### DIFF
--- a/public/js/lib/httpClient.js
+++ b/public/js/lib/httpClient.js
@@ -1,7 +1,7 @@
 import axios from 'https://esm.sh/axios';
 
 const getBaseURL = () => {
-  return window.MC_BASE_URL || "https://test.mermaidchart.com";
+  return window.MC_BASE_URL ;
 };
 
 const httpClient = axios.create({


### PR DESCRIPTION
This pull request makes a minor change to the base URL configuration in the `httpClient` library. The default fallback URL for the base API endpoint has been removed, so the code now relies solely on the `window.MC_BASE_URL` variable.

* Removed the default fallback value `"https://test.mermaidchart.com"` from the `getBaseURL` function in `public/js/lib/httpClient.js`, making `window.MC_BASE_URL` the only source for the base URL.