### PR TITLE
updated the bseUrl for Test

### DIFF
--- a/public/js/lib/httpClient.js
+++ b/public/js/lib/httpClient.js
@@ -1,7 +1,7 @@
 import axios from 'https://esm.sh/axios';
 
 const getBaseURL = () => {
-  return window.MC_BASE_URL || "https://test.mermaidchart.com";
+  return window.MC_BASE_URL || "https://mermaid.ai";
 };
 
 const httpClient = axios.create({

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,7 @@
 import {fetchToken, saveToken} from '../utils/index.js';
 import {MermaidChart} from '../utils/MermaidChart.js';
 
-const MC_BASE_URL = process.env.MC_BASE_URL || "https://test.mermaidchart.com";
+const MC_BASE_URL = "https://mermaid.ai";
 
 export default function routes(app, addon) {
 

--- a/utils/MermaidChart.js
+++ b/utils/MermaidChart.js
@@ -2,7 +2,7 @@ import {v4 as uuid} from 'uuid';
 import fetch from 'node-fetch';
 import {getEncodedSHA256Hash} from './index.js';
 
-const defaultBaseURL = 'https://test.mermaidchart.com';
+const defaultBaseURL = 'https://mermaid.ai';
 
 const CLIENT_KEY = 'all';
 


### PR DESCRIPTION
This pull request updates the base URL used throughout the codebase for the Mermaid Chart service, changing it from the test environment to the production environment. This ensures that all requests and integrations now point to the production service at `https://mermaid.ai`.

**Base URL update:**

* Changed the default and environment-based base URLs from `https://test.mermaidchart.com` to `https://mermaid.ai` in `public/js/lib/httpClient.js`, `routes/index.js`, and `utils/MermaidChart.js`. [[1]](diffhunk://#diff-47254aa09e5c32f91827c214b819285b32de30fdf654f240c1970345263e019fL4-R4) [[2]](diffhunk://#diff-103b73514ced7155e7e33849be2ab49fcbf55e6ff018e0e5356a82d74e6c7e09L4-R4) [[3]](diffhunk://#diff-42caf36fa829b00e351fefd8a203cbcc1ace68794fe4dc4aac4a4a2156bf77e9L5-R5)