### PR TITLE
updated baseUrl

### DIFF
--- a/atlassian-connect.json
+++ b/atlassian-connect.json
@@ -3,7 +3,7 @@
   "name": "Mermaid chart application",
   "description": "Mermaid chart application",
   "//baseUrl": "{{localBaseUrl}}",
-  "baseUrl": "https://confluencestage.mermaidchart.com",
+  "baseUrl": "https://confluencetest.mermaidchart.com",
   "authentication": {
     "type": "jwt"
   },

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   "preview": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://confluencestage.mermaidchart.com",
+    "localBaseUrl": "https://confluencetest.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -23,7 +23,7 @@
   "production": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://confluencestage.mermaidchart.com",
+    "localBaseUrl": "https://confluencetest.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",


### PR DESCRIPTION
This pull request updates the environment configuration to use the `confluencetest` domain instead of `confluencestage` for both the application base URL and local base URLs across different environments.

Configuration updates:

* Changed the `baseUrl` in `atlassian-connect.json` from `https://confluencestage.mermaidchart.com` to `https://confluencetest.mermaidchart.com`.
* Updated the `localBaseUrl` in both the `preview` and `production` sections of `config.json` to use `https://confluencetest.mermaidchart.com` instead of `https://confluencestage.mermaidchart.com`. [[1]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL15-R15) [[2]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL26-R26)